### PR TITLE
Upgrade to LDK 0.0.111, Improve SQL Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-base64 = "0.13.0"
-bech32 = "0.8"
 bitcoin = "0.28.1"
-bitcoin-bech32 = "0.12"
 lightning = { version = "0.0.110" }
 lightning-block-sync = { version = "0.0.110", features=["rest-client"] }
 lightning-net-tokio = { version = "0.0.110" }
-chrono = "0.4"
-hex = "0.3"
-rand = "0.4"
 tokio = { version = "1.14.1", features = ["full"] }
 tokio-postgres = { version="0.7.5" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-bitcoin = "0.28.1"
-lightning = { version = "0.0.110" }
-lightning-block-sync = { version = "0.0.110", features=["rest-client"] }
-lightning-net-tokio = { version = "0.0.110" }
+bitcoin = "0.29"
+lightning = { version = "0.0.111" }
+lightning-block-sync = { version = "0.0.111", features=["rest-client"] }
+lightning-net-tokio = { version = "0.0.111" }
 tokio = { version = "1.14.1", features = ["full"] }
 tokio-postgres = { version="0.7.5" }
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ lightning-block-sync = { version = "0.0.110", features=["rest-client"] }
 lightning-net-tokio = { version = "0.0.110" }
 tokio = { version = "1.14.1", features = ["full"] }
 tokio-postgres = { version="0.7.5" }
+futures = "0.3"
 
 [profile.release]
 opt-level = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,7 @@ pub(crate) fn db_channel_update_table_creation_query() -> &'static str {
 
 pub(crate) fn db_index_creation_query() -> &'static str {
 	"
+	CREATE INDEX IF NOT EXISTS channel_updates_seen ON channel_updates(seen, short_channel_id, direction) INCLUDE (id, blob_signed);
 	CREATE INDEX IF NOT EXISTS channel_updates_scid_seen ON channel_updates(short_channel_id, seen) INCLUDE (blob_signed);
 	CREATE INDEX IF NOT EXISTS channel_updates_seen_scid ON channel_updates(seen, short_channel_id);
 	CREATE INDEX IF NOT EXISTS channel_updates_scid_dir_seen ON channel_updates(short_channel_id ASC, direction ASC, seen DESC) INCLUDE (id, blob_signed);

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,13 @@ pub(crate) fn db_index_creation_query() -> &'static str {
 	"
 }
 
+pub(crate) async fn upgrade_db(schema: i32, client: &mut tokio_postgres::Client) {
+	match schema {
+		SCHEMA_VERSION => {},
+		_ => panic!("Unknown schema in db: {}, we support up to {}", schema, SCHEMA_VERSION),
+	}
+}
+
 /// EDIT ME
 pub(crate) fn ln_peers() -> Vec<(PublicKey, SocketAddr)> {
 	vec![

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use crate::hex_utils;
 
 use futures::stream::{FuturesUnordered, StreamExt};
 
-pub(crate) const SCHEMA_VERSION: i32 = 7;
+pub(crate) const SCHEMA_VERSION: i32 = 8;
 pub(crate) const SNAPSHOT_CALCULATION_INTERVAL: u32 = 3600 * 24; // every 24 hours, in seconds
 pub(crate) const DOWNLOAD_NEW_GOSSIP: bool = true;
 
@@ -79,12 +79,9 @@ pub(crate) fn db_channel_update_table_creation_query() -> &'static str {
 
 pub(crate) fn db_index_creation_query() -> &'static str {
 	"
-	CREATE INDEX IF NOT EXISTS channels_seen ON channel_announcements(seen);
-	CREATE INDEX IF NOT EXISTS channel_updates_scid ON channel_updates(short_channel_id);
-	CREATE INDEX IF NOT EXISTS channel_updates_direction ON channel_updates (short_channel_id, direction);
-	CREATE INDEX IF NOT EXISTS channel_updates_seen ON channel_updates(seen);
-	CREATE INDEX IF NOT EXISTS channel_updates_scid_seen ON channel_updates(short_channel_id, seen);
-	CREATE INDEX IF NOT EXISTS channel_updates_scid_dir_seen ON channel_updates(short_channel_id ASC, direction ASC, seen DESC);
+	CREATE INDEX IF NOT EXISTS channel_updates_scid_seen ON channel_updates(short_channel_id, seen) INCLUDE (blob_signed);
+	CREATE INDEX IF NOT EXISTS channel_updates_seen_scid ON channel_updates(seen, short_channel_id);
+	CREATE INDEX IF NOT EXISTS channel_updates_scid_dir_seen ON channel_updates(short_channel_id ASC, direction ASC, seen DESC) INCLUDE (id, blob_signed);
 	CREATE UNIQUE INDEX IF NOT EXISTS channel_updates_key ON channel_updates (short_channel_id, direction, timestamp);
 	"
 }
@@ -126,8 +123,6 @@ pub(crate) async fn upgrade_db(schema: i32, client: &mut tokio_postgres::Client)
 			}
 			while let Some(_) = updates.next().await { }
 		}
-		tx.execute("CREATE INDEX channel_updates_scid ON channel_updates(short_channel_id)", &[]).await.unwrap();
-		tx.execute("CREATE INDEX channel_updates_direction ON channel_updates (short_channel_id, direction)", &[]).await.unwrap();
 		tx.execute("ALTER TABLE channel_updates ALTER short_channel_id DROP DEFAULT", &[]).await.unwrap();
 		tx.execute("ALTER TABLE channel_updates ALTER short_channel_id SET NOT NULL", &[]).await.unwrap();
 		tx.execute("ALTER TABLE channel_updates ALTER direction DROP DEFAULT", &[]).await.unwrap();
@@ -188,6 +183,17 @@ pub(crate) async fn upgrade_db(schema: i32, client: &mut tokio_postgres::Client)
 		tx.execute("ALTER TABLE channel_updates ALTER blob_signed SET NOT NULL", &[]).await.unwrap();
 		tx.execute("CREATE UNIQUE INDEX channel_updates_key ON channel_updates (short_channel_id, direction, timestamp)", &[]).await.unwrap();
 		tx.execute("UPDATE config SET db_schema = 7 WHERE id = 1", &[]).await.unwrap();
+		tx.commit().await.unwrap();
+	}
+	if schema >= 1 && schema <= 7 {
+		let tx = client.transaction().await.unwrap();
+		tx.execute("DROP INDEX channels_seen", &[]).await.unwrap();
+		tx.execute("DROP INDEX channel_updates_scid", &[]).await.unwrap();
+		tx.execute("DROP INDEX channel_updates_direction", &[]).await.unwrap();
+		tx.execute("DROP INDEX channel_updates_seen", &[]).await.unwrap();
+		tx.execute("DROP INDEX channel_updates_scid_seen", &[]).await.unwrap();
+		tx.execute("DROP INDEX channel_updates_scid_dir_seen", &[]).await.unwrap();
+		tx.execute("UPDATE config SET db_schema = 8 WHERE id = 1", &[]).await.unwrap();
 		tx.commit().await.unwrap();
 	}
 	if schema <= 1 || schema > SCHEMA_VERSION {

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,8 @@ pub(crate) fn db_index_creation_query() -> &'static str {
 	CREATE INDEX IF NOT EXISTS channel_updates_scid ON channel_updates(short_channel_id);
 	CREATE INDEX IF NOT EXISTS channel_updates_direction ON channel_updates (short_channel_id, direction);
 	CREATE INDEX IF NOT EXISTS channel_updates_seen ON channel_updates(seen);
+	CREATE INDEX IF NOT EXISTS channel_updates_scid_seen ON channel_updates(short_channel_id, seen);
+	CREATE INDEX IF NOT EXISTS channel_updates_scid_dir_seen ON channel_updates(short_channel_id ASC, direction ASC, seen DESC);
 	"
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,17 @@
+use std::convert::TryInto;
 use std::env;
 use std::net::SocketAddr;
+use std::io::Cursor;
 use bitcoin::secp256k1::PublicKey;
+use lightning::ln::msgs::ChannelAnnouncement;
+use lightning::util::ser::Readable;
 use lightning_block_sync::http::HttpEndpoint;
 use tokio_postgres::Config;
 use crate::hex_utils;
 
-pub(crate) const SCHEMA_VERSION: i32 = 2;
+use futures::stream::{FuturesUnordered, StreamExt};
+
+pub(crate) const SCHEMA_VERSION: i32 = 5;
 pub(crate) const SNAPSHOT_CALCULATION_INTERVAL: u32 = 3600 * 24; // every 24 hours, in seconds
 pub(crate) const DOWNLOAD_NEW_GOSSIP: bool = true;
 
@@ -47,7 +53,7 @@ pub(crate) fn db_config_table_creation_query() -> &'static str {
 pub(crate) fn db_announcement_table_creation_query() -> &'static str {
 	"CREATE TABLE IF NOT EXISTS channel_announcements (
 		id SERIAL PRIMARY KEY,
-		short_channel_id character varying(255) NOT NULL UNIQUE,
+		short_channel_id bigint NOT NULL UNIQUE,
 		block_height integer,
 		announcement_signed BYTEA,
 		seen timestamp NOT NULL DEFAULT NOW()
@@ -55,13 +61,14 @@ pub(crate) fn db_announcement_table_creation_query() -> &'static str {
 }
 
 pub(crate) fn db_channel_update_table_creation_query() -> &'static str {
+	// We'll run out of room in composite index at block 8,388,608 or in the year 2286
 	"CREATE TABLE IF NOT EXISTS channel_updates (
 		id SERIAL PRIMARY KEY,
-		composite_index character varying(255) UNIQUE,
-		short_channel_id character varying(255),
+		composite_index character(29) UNIQUE,
+		short_channel_id bigint NOT NULL,
 		timestamp bigint,
 		channel_flags integer,
-		direction integer,
+		direction boolean NOT NULL,
 		disable boolean,
 		cltv_expiry_delta integer,
 		htlc_minimum_msat bigint,
@@ -77,7 +84,7 @@ pub(crate) fn db_index_creation_query() -> &'static str {
 	"
 	CREATE INDEX IF NOT EXISTS channels_seen ON channel_announcements(seen);
 	CREATE INDEX IF NOT EXISTS channel_updates_scid ON channel_updates(short_channel_id);
-	CREATE INDEX IF NOT EXISTS channel_updates_direction ON channel_updates(direction);
+	CREATE INDEX IF NOT EXISTS channel_updates_direction ON channel_updates (short_channel_id, direction);
 	CREATE INDEX IF NOT EXISTS channel_updates_seen ON channel_updates(seen);
 	"
 }
@@ -88,6 +95,76 @@ pub(crate) async fn upgrade_db(schema: i32, client: &mut tokio_postgres::Client)
 		tx.execute("ALTER TABLE channel_updates DROP COLUMN chain_hash", &[]).await.unwrap();
 		tx.execute("ALTER TABLE channel_announcements DROP COLUMN chain_hash", &[]).await.unwrap();
 		tx.execute("UPDATE config SET db_schema = 2 WHERE id = 1", &[]).await.unwrap();
+		tx.commit().await.unwrap();
+	}
+	if schema == 1 || schema == 2 {
+		let tx = client.transaction().await.unwrap();
+		tx.execute("ALTER TABLE channel_updates DROP COLUMN short_channel_id", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ADD COLUMN short_channel_id bigint DEFAULT null", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates DROP COLUMN direction", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ADD COLUMN direction boolean DEFAULT null", &[]).await.unwrap();
+		loop {
+			let rows = tx.query("SELECT id, composite_index FROM channel_updates WHERE short_channel_id IS NULL LIMIT 50000", &[]).await.unwrap();
+			if rows.is_empty() { break; }
+			let mut updates = FuturesUnordered::new();
+			for row in rows {
+				let id: i32 = row.get("id");
+				let index: String = row.get("composite_index");
+				let tx_ref = &tx;
+				updates.push(async move {
+					let mut index_iter = index.split(":");
+					let scid_hex = index_iter.next().unwrap();
+					index_iter.next().unwrap();
+					let direction_str = index_iter.next().unwrap();
+					assert!(direction_str == "1" || direction_str == "0");
+					let direction = direction_str == "1";
+					let scid_be_bytes = hex_utils::to_vec(scid_hex).unwrap();
+					let scid = i64::from_be_bytes(scid_be_bytes.try_into().unwrap());
+					assert!(scid > 0); // Will roll over in some 150 years or so
+					tx_ref.execute("UPDATE channel_updates SET short_channel_id = $1, direction = $2 WHERE id = $3", &[&scid, &direction, &id]).await.unwrap();
+				});
+			}
+			while let Some(_) = updates.next().await { }
+		}
+		tx.execute("CREATE INDEX channel_updates_scid ON channel_updates(short_channel_id)", &[]).await.unwrap();
+		tx.execute("CREATE INDEX channel_updates_direction ON channel_updates (short_channel_id, direction)", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ALTER short_channel_id DROP DEFAULT", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ALTER short_channel_id SET NOT NULL", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ALTER direction DROP DEFAULT", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ALTER direction SET NOT NULL", &[]).await.unwrap();
+		tx.execute("UPDATE config SET db_schema = 3 WHERE id = 1", &[]).await.unwrap();
+		tx.commit().await.unwrap();
+	}
+	if schema >= 1 && schema <= 3 {
+		let tx = client.transaction().await.unwrap();
+		tx.execute("ALTER TABLE channel_announcements DROP COLUMN short_channel_id", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_announcements ADD COLUMN short_channel_id bigint DEFAULT null", &[]).await.unwrap();
+		loop {
+			let rows = tx.query("SELECT id, announcement_signed FROM channel_announcements WHERE short_channel_id IS NULL LIMIT 10000", &[]).await.unwrap();
+			if rows.is_empty() { break; }
+			let mut updates = FuturesUnordered::new();
+			for row in rows {
+				let id: i32 = row.get("id");
+				let announcement: Vec<u8> = row.get("announcement_signed");
+				let tx_ref = &tx;
+				updates.push(async move {
+					let scid = ChannelAnnouncement::read(&mut Cursor::new(announcement)).unwrap().contents.short_channel_id as i64;
+					assert!(scid > 0); // Will roll over in some 150 years or so
+					tx_ref.execute("UPDATE channel_announcements SET short_channel_id = $1 WHERE id = $2", &[&scid, &id]).await.unwrap();
+				});
+			}
+			while let Some(_) = updates.next().await { }
+		}
+		tx.execute("ALTER TABLE channel_announcements ADD CONSTRAINT channel_announcements_short_channel_id_key UNIQUE (short_channel_id)", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_announcements ALTER short_channel_id DROP DEFAULT", &[]).await.unwrap();
+		tx.execute("ALTER TABLE channel_announcements ALTER short_channel_id SET NOT NULL", &[]).await.unwrap();
+		tx.execute("UPDATE config SET db_schema = 4 WHERE id = 1", &[]).await.unwrap();
+		tx.commit().await.unwrap();
+	}
+	if schema >= 1 && schema <= 4 {
+		let tx = client.transaction().await.unwrap();
+		tx.execute("ALTER TABLE channel_updates ALTER composite_index SET DATA TYPE character(29)", &[]).await.unwrap();
+		tx.execute("UPDATE config SET db_schema = 5 WHERE id = 1", &[]).await.unwrap();
 		tx.commit().await.unwrap();
 	}
 	if schema <= 1 || schema > SCHEMA_VERSION {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use bitcoin::secp256k1::PublicKey;
+use lightning::ln::features::{InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{ChannelAnnouncement, ChannelUpdate, Init, LightningError, NodeAnnouncement, QueryChannelRange, QueryShortChannelIds, ReplyChannelRange, ReplyShortChannelIdsEnd, RoutingMessageHandler};
 use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lightning::util::events::{MessageSendEvent, MessageSendEventsProvider};
@@ -97,12 +98,12 @@ impl RoutingMessageHandler for GossipRouter {
 		Ok(output_value)
 	}
 
-	fn get_next_channel_announcements(&self, starting_point: u64, batch_amount: u8) -> Vec<(ChannelAnnouncement, Option<ChannelUpdate>, Option<ChannelUpdate>)> {
-		self.native_router.get_next_channel_announcements(starting_point, batch_amount)
+	fn get_next_channel_announcement(&self, starting_point: u64) -> Option<(ChannelAnnouncement, Option<ChannelUpdate>, Option<ChannelUpdate>)> {
+		self.native_router.get_next_channel_announcement(starting_point)
 	}
 
-	fn get_next_node_announcements(&self, starting_point: Option<&PublicKey>, batch_amount: u8) -> Vec<NodeAnnouncement> {
-		self.native_router.get_next_node_announcements(starting_point, batch_amount)
+	fn get_next_node_announcement(&self, starting_point: Option<&PublicKey>) -> Option<NodeAnnouncement> {
+		self.native_router.get_next_node_announcement(starting_point)
 	}
 
 	fn peer_connected(&self, their_node_id: &PublicKey, init: &Init) {
@@ -123,5 +124,13 @@ impl RoutingMessageHandler for GossipRouter {
 
 	fn handle_query_short_channel_ids(&self, their_node_id: &PublicKey, msg: QueryShortChannelIds) -> Result<(), LightningError> {
 		self.native_router.handle_query_short_channel_ids(their_node_id, msg)
+	}
+
+	fn provided_init_features(&self, their_node_id: &PublicKey) -> InitFeatures {
+		self.native_router.provided_init_features(their_node_id)
+	}
+
+	fn provided_node_features(&self) -> NodeFeatures {
+		self.native_router.provided_node_features()
 	}
 }

--- a/src/hex_utils.rs
+++ b/src/hex_utils.rs
@@ -21,13 +21,14 @@ pub fn to_vec(hex: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
-#[inline]
-pub fn hex_str(value: &[u8]) -> String {
-    let mut res = String::with_capacity(64);
-    for v in value {
-        res += &format!("{:02x}", v);
-    }
-    res
+pub fn to_composite_index(scid: i64, timestamp: i64, direction: bool) -> String {
+	let scid_be = scid.to_be_bytes();
+	let res = format!("{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}:{}:{}",
+		scid_be[0], scid_be[1], scid_be[2], scid_be[3],
+		scid_be[4], scid_be[5], scid_be[6], scid_be[7],
+		timestamp, direction as u8);
+	assert_eq!(res.len(), 29); // Our SQL Type requires len of 29
+	res
 }
 
 pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {

--- a/src/hex_utils.rs
+++ b/src/hex_utils.rs
@@ -21,16 +21,6 @@ pub fn to_vec(hex: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
-pub fn to_composite_index(scid: i64, timestamp: i64, direction: bool) -> String {
-	let scid_be = scid.to_be_bytes();
-	let res = format!("{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}:{}:{}",
-		scid_be[0], scid_be[1], scid_be[2], scid_be[3],
-		scid_be[4], scid_be[5], scid_be[6], scid_be[7],
-		timestamp, direction as u8);
-	assert_eq!(res.len(), 29); // Our SQL Type requires len of 29
-	res
-}
-
 pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
     let data = match to_vec(&hex[0..33 * 2]) {
         Some(bytes) => bytes,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -109,8 +109,7 @@ impl GossipPersister {
 
 			match &gossip_message {
 				GossipMessage::ChannelAnnouncement(announcement) => {
-					let scid = announcement.contents.short_channel_id;
-					let scid_hex = hex_utils::hex_str(&scid.to_be_bytes());
+					let scid = announcement.contents.short_channel_id as i64;
 					// scid is 8 bytes
 					// block height is the first three bytes
 					// to obtain block height, shift scid right by 5 bytes (40 bits)
@@ -126,7 +125,7 @@ impl GossipPersister {
 							block_height, \
 							announcement_signed \
 						) VALUES ($1, $2, $3) ON CONFLICT (short_channel_id) DO NOTHING", &[
-							&scid_hex,
+							&scid,
 							&block_height,
 							&announcement_signed
 						]).await;
@@ -135,7 +134,7 @@ impl GossipPersister {
 					}
 				}
 				GossipMessage::ChannelUpdate(update) => {
-					let scid = update.contents.short_channel_id;
+					let scid = update.contents.short_channel_id as i64;
 					let scid_hex = hex_utils::hex_str(&scid.to_be_bytes());
 
 					let timestamp = update.contents.timestamp as i64;
@@ -173,10 +172,10 @@ impl GossipPersister {
 							blob_signed \
 						) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)  ON CONFLICT (composite_index) DO NOTHING", &[
 							&composite_index,
-							&scid_hex,
+							&scid,
 							&timestamp,
 							&channel_flags,
-							&direction,
+							&(direction == 1),
 							&disable,
 							&cltv_expiry_delta,
 							&htlc_minimum_msat,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -135,15 +135,13 @@ impl GossipPersister {
 				}
 				GossipMessage::ChannelUpdate(update) => {
 					let scid = update.contents.short_channel_id as i64;
-					let scid_hex = hex_utils::hex_str(&scid.to_be_bytes());
 
 					let timestamp = update.contents.timestamp as i64;
 
-					let channel_flags = update.contents.flags as i32;
-					let direction = channel_flags & 1;
-					let disable = (channel_flags & 2) > 0;
+					let direction = (update.contents.flags & 1) == 1;
+					let disable = (update.contents.flags & 2) > 0;
 
-					let composite_index = format!("{}:{}:{}", scid_hex, timestamp, direction);
+					let composite_index = hex_utils::to_composite_index(scid, timestamp, direction);
 
 					let cltv_expiry_delta = update.contents.cltv_expiry_delta as i32;
 					let htlc_minimum_msat = update.contents.htlc_minimum_msat as i64;
@@ -174,8 +172,8 @@ impl GossipPersister {
 							&composite_index,
 							&scid,
 							&timestamp,
-							&channel_flags,
-							&(direction == 1),
+							&(update.contents.flags as i32),
+							&direction,
 							&disable,
 							&cltv_expiry_delta,
 							&htlc_minimum_msat,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -2,6 +2,7 @@ use std::cmp::max;
 use std::collections::HashMap;
 
 use bitcoin::BlockHash;
+use bitcoin::hashes::Hash;
 use lightning::ln::msgs::{UnsignedChannelAnnouncement, UnsignedChannelUpdate};
 use lightning::util::ser::{BigSize, Writeable};
 
@@ -93,7 +94,7 @@ pub(super) fn serialize_delta_set(delta_set: DeltaSet, last_sync_timestamp: u32)
 		announcements: vec![],
 		updates: vec![],
 		full_update_defaults: Default::default(),
-		chain_hash: Default::default(),
+		chain_hash: BlockHash::all_zeros(),
 		latest_seen: 0,
 	};
 

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -36,10 +36,12 @@ pub(crate) async fn download_gossip(persistence_sender: mpsc::Sender<GossipMessa
 	let message_handler = MessageHandler {
 		chan_handler: ErroringMessageHandler::new(),
 		route_handler: Arc::clone(&router),
+		onion_message_handler: IgnoringMessageHandler {},
 	};
 	let peer_handler = Arc::new(PeerManager::new(
 		message_handler,
 		our_node_secret,
+		0xdeadbeef,
 		&random_data,
 		TestLogger::new(),
 		IgnoringMessageHandler {},

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -9,7 +11,6 @@ use lightning::ln::peer_handler::{
 	ErroringMessageHandler, IgnoringMessageHandler, MessageHandler, PeerManager,
 };
 use lightning::routing::gossip::NetworkGraph;
-use rand::{Rng, thread_rng};
 use tokio::sync::mpsc;
 
 use crate::{config, TestLogger};
@@ -19,12 +20,17 @@ use crate::types::{GossipMessage, GossipPeerManager};
 pub(crate) async fn download_gossip(persistence_sender: mpsc::Sender<GossipMessage>,
 		completion_sender: mpsc::Sender<()>,
 		network_graph: Arc<NetworkGraph<TestLogger>>) {
-	let mut key = [0; 32];
-	let mut random_data = [0; 32];
-	thread_rng().fill_bytes(&mut key);
-	thread_rng().fill_bytes(&mut random_data);
-	let our_node_secret = SecretKey::from_slice(&key).unwrap();
+	let mut key = [42; 32];
+	let mut random_data = [43; 32];
+	// Get something psuedo-random from std.
+	let mut key_hasher = RandomState::new().build_hasher();
+	key_hasher.write_u8(1);
+	key[0..8].copy_from_slice(&key_hasher.finish().to_ne_bytes());
+	let mut rand_hasher = RandomState::new().build_hasher();
+	rand_hasher.write_u8(2);
+	random_data[0..8].copy_from_slice(&rand_hasher.finish().to_ne_bytes());
 
+	let our_node_secret = SecretKey::from_slice(&key).unwrap();
 	let router = Arc::new(GossipRouter::new(network_graph, persistence_sender.clone()));
 
 	let message_handler = MessageHandler {

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use crate::downloader::GossipRouter;
 use crate::verifier::ChainVerifier;
 
 pub(crate) type GossipChainAccess = Arc<ChainVerifier>;
-pub(crate) type GossipPeerManager = Arc<PeerManager<lightning_net_tokio::SocketDescriptor, ErroringMessageHandler, Arc<GossipRouter>, TestLogger, IgnoringMessageHandler>>;
+pub(crate) type GossipPeerManager = Arc<PeerManager<lightning_net_tokio::SocketDescriptor, ErroringMessageHandler, Arc<GossipRouter>, IgnoringMessageHandler, TestLogger, IgnoringMessageHandler>>;
 
 #[derive(Debug)]
 pub(crate) enum GossipMessage {


### PR DESCRIPTION
Hopefully this somewhat reduces the rather-substantial write IO the gossip sync server causes postgres to do, plus of course fixes the reject-half-of-channels issue. Needs to wait on LDK 111 shipping, of course, but I'm running with the new schema in prod, we'll see how it does.