### PR TITLE
Replace `channel(100)` with `unbounded_channel()`

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -11,14 +11,14 @@ use crate::{config, TestLogger};
 use crate::types::GossipMessage;
 
 pub(crate) struct GossipPersister {
-	gossip_persistence_receiver: mpsc::Receiver<GossipMessage>,
+	gossip_persistence_receiver: mpsc::UnboundedReceiver<GossipMessage>,
 	network_graph: Arc<NetworkGraph<TestLogger>>,
 }
 
 impl GossipPersister {
-	pub fn new(network_graph: Arc<NetworkGraph<TestLogger>>) -> (Self, mpsc::Sender<GossipMessage>) {
+	pub fn new(network_graph: Arc<NetworkGraph<TestLogger>>) -> (Self, mpsc::UnboundedSender<GossipMessage>) {
 		let (gossip_persistence_sender, gossip_persistence_receiver) =
-			mpsc::channel::<GossipMessage>(100);
+			mpsc::unbounded_channel::<GossipMessage>();
 		(GossipPersister {
 			gossip_persistence_receiver,
 			network_graph

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -6,7 +6,6 @@ use std::time::{Duration, Instant};
 
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
-use lightning;
 use lightning::ln::peer_handler::{
 	ErroringMessageHandler, IgnoringMessageHandler, MessageHandler, PeerManager,
 };
@@ -18,7 +17,7 @@ use crate::{config, TestLogger};
 use crate::downloader::GossipRouter;
 use crate::types::{GossipMessage, GossipPeerManager};
 
-pub(crate) async fn download_gossip(persistence_sender: mpsc::Sender<GossipMessage>,
+pub(crate) async fn download_gossip(persistence_sender: mpsc::UnboundedSender<GossipMessage>,
 		completion_sender: mpsc::Sender<()>,
 		network_graph: Arc<NetworkGraph<TestLogger>>) {
 	let mut key = [42; 32];
@@ -33,7 +32,7 @@ pub(crate) async fn download_gossip(persistence_sender: mpsc::Sender<GossipMessa
 
 	let keys_manager = Arc::new(KeysManager::new(&key, 0xdeadbeef, 0xdeadbeef));
 
-	let router = Arc::new(GossipRouter::new(network_graph, persistence_sender.clone()));
+	let router = Arc::new(GossipRouter::new(network_graph, persistence_sender));
 
 	let message_handler = MessageHandler {
 		chan_handler: ErroringMessageHandler::new(),


### PR DESCRIPTION
To prevent deadlock on sending to the channel. Fixes #32.

Note there is a chance to get OOM if the receiver (writing to the database) is very slow.