### PR TITLE
Fix dummy symlink

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -95,8 +95,9 @@ impl Snapshotter {
 				fs::write(&dummy_snapshot_path, dummy_snapshot).unwrap();
 
 				let dummy_symlink_path = format!("{}/{}.bin", pending_symlink_directory, reference_timestamp);
-				println!("Symlinking dummy: {} -> {}", dummy_symlink_path, dummy_snapshot_path);
-				symlink(&dummy_snapshot_path, &dummy_symlink_path).unwrap();
+				let relative_dummy_snapshot_path = format!("{}/{}", relative_symlink_to_snapshot_path, dummy_filename);
+				println!("Symlinking dummy: {} -> {}", dummy_symlink_path, relative_dummy_snapshot_path);
+				symlink(&relative_dummy_snapshot_path, &dummy_symlink_path).unwrap();
 			}
 
 			for i in 0..10_001u64 {


### PR DESCRIPTION
The commit changes the symlink for the snapshot for the current date from `./res/snapshots_pending/empty_delta.lngossip` to `./res/snapshots/empty_delta.lngossip` such that nginx does not retrun 404, but 200 with the dummy snapshot.