### PR TITLE
Add config for worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ can be made by setting environment variables, whose usage is as follows:
 | RAPID_GOSSIP_SYNC_SERVER_DB_PASSWORD | _None_              | Password to access Postgres                                                                                |
 | RAPID_GOSSIP_SYNC_SERVER_DB_NAME     | ln_graph_sync       | Name of the database to be used for gossip storage                                                         |
 | RAPID_GOSSIP_SYNC_SERVER_NETWORK     | mainnet             | Network to operate in. Possible values are mainnet, testnet, signet, regtest                               |
+| RAPID_GOSSIP_SYNC_SERVER_WORKERS     | # of CPUs           | Number of Tokio workers to use in the runtime. If not set, uses the Tokio default of 1 per CPU.            |
 | BITCOIN_REST_DOMAIN                  | 127.0.0.1           | Domain of the [bitcoind REST server](https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md) |
 | BITCOIN_REST_PORT                    | 8332                | HTTP port of the bitcoind REST server                                                                      |
 | BITCOIN_REST_PATH                    | /rest/              | Path infix to access the bitcoind REST endpoints                                                           |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,69 @@
+use std::{
+    env::{self, VarError}, io::Error, io::ErrorKind,
+};
 use rapid_gossip_sync_server::RapidSyncProcessor;
 
-#[tokio::main]
-async fn main() {
-	RapidSyncProcessor::new().start_sync().await;
+const WORKER_THREADS_ENV_VAR: &str = "RAPID_GOSSIP_SYNC_SERVER_WORKERS";
+
+fn main() {
+    let mut rt = tokio::runtime::Builder::new_multi_thread();
+    match get_tokio_workers() {
+        Ok(Some(workers)) => {
+            println!("Using {workers} Tokio worker threads");
+            rt.worker_threads(workers);
+        }
+        Err(e) => {
+            println!("{WORKER_THREADS_ENV_VAR} var was set, but could not be used. {e}");
+            return;
+        }
+        _ => println!("Using default number of Tokio worker threads"),
+    }
+    rt.enable_all()
+        .build()
+        .unwrap()
+        .block_on(RapidSyncProcessor::new().start_sync())
+}
+
+fn get_tokio_workers() -> Result<Option<usize>, Error> {
+    match env::var(WORKER_THREADS_ENV_VAR) {
+        Ok(workers_string) => match workers_string.parse() {
+            Ok(workers) => Ok(Some(workers)),
+            Err(e) => Err(Error::new(ErrorKind::InvalidInput, format!("cannot parse usize: {e}"))),
+        },
+        Err(VarError::NotUnicode(v)) => Err(Error::new(ErrorKind::InvalidInput, format!("not unicode: {v:?}"))),
+        Err(VarError::NotPresent) => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_get_tokio_workers_no_var_set() {
+        // Clear the environment variable to simulate it not being present.
+        env::remove_var(WORKER_THREADS_ENV_VAR);
+
+        // In this case, we expect Ok(None).
+        assert_eq!(get_tokio_workers().unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_tokio_workers_var_set() {
+        // Set the environment variable to a valid usize.
+        env::set_var(WORKER_THREADS_ENV_VAR, "10");
+
+        // In this case, we expect Ok(Some(10)).
+        assert_eq!(get_tokio_workers().unwrap(), Some(10));
+    }
+
+    #[test]
+    fn test_get_tokio_workers_not_parsable_var_set() {
+        // Set the environment variable to a not parsable value.
+        env::set_var(WORKER_THREADS_ENV_VAR, "cannotparse");
+
+        // In this case, we expect an error.
+        assert!(get_tokio_workers().is_err());
+    }
 }


### PR DESCRIPTION
Hi,

My colleague @marctyndel has been running into freezing RGSS instances, which would persist until he manually cleared some cached data. After conferring with him I suggested patching `main.rs` to increase the number of workers in the default multithreaded runtime. This cleared the condition without requiring a reset of the cached data. 

In our work operating an LDK lightning node, we found we needed to increase the number of workers greater than one-per-CPU as we approached 100 peers and added a little bit of extra work to the Background Processor. I suspect since there's a lot of overlap here, there's a similar tendency for a low number of workers to get full task queues and possibly deadlock once enough gossip is coming through.

This PR adds an environment variable where one can set the worker count. If not set, the program should run with the same runtime it gets today from `[tokio::main]`.

