### PR TITLE
Support JSON-RPC verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 bitcoin = "0.29"
 lightning = { version = "0.0.117" }
-lightning-block-sync = { version = "0.0.117", features=["rest-client"] }
+lightning-block-sync = { version = "0.0.117", features=["rest-client", "rpc-client"] }
 lightning-net-tokio = { version = "0.0.117" }
 tokio = { version = "1.25", features = ["full"] }
 tokio-postgres = { version = "=0.7.5" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,26 @@ pub(crate) fn bitcoin_rest_endpoint() -> HttpEndpoint {
 	HttpEndpoint::for_host(host).with_port(port).with_path(path)
 }
 
+pub(crate) fn bitcoin_rpc_endpoint() -> HttpEndpoint {
+	let host = env::var("BITCOIN_RPC_DOMAIN").unwrap_or("127.0.0.1".to_string());
+	let port = env::var("BITCOIN_RPC_PORT")
+		.unwrap_or("8332".to_string())
+		.parse::<u16>()
+		.expect("BITCOIN_RPC_PORT env variable must be a u16.");
+	let path = env::var("BITCOIN_RPC_PATH").unwrap_or("/".to_string());
+	HttpEndpoint::for_host(host).with_port(port).with_path(path)
+}
+
+pub(crate) fn bitcoin_rpc_credentials() -> String {
+	let user = env::var("BITCOIN_RPC_USER").unwrap_or("user".to_string());
+	let password = env::var("BITCOIN_RPC_PASSWORD").unwrap_or("password".to_string());
+	format!("{}:{}", user, password)
+}
+
+pub(crate) fn use_bitcoin_rpc_api() -> bool {
+	env::var("USE_BITCOIN_RPC_API").unwrap_or("false".to_string()) == "true"
+} 
+
 pub(crate) fn db_config_table_creation_query() -> &'static str {
 	"CREATE TABLE IF NOT EXISTS config (
 		id SERIAL PRIMARY KEY,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -17,8 +17,46 @@ use lightning_block_sync::rest::RestClient;
 use crate::config;
 use crate::types::GossipPeerManager;
 
+enum AnyChainSource {
+	Rest(RestClient)
+}
+
+impl BlockSource for AnyChainSource {
+    fn get_header<'a>(&'a self, header_hash: &'a BlockHash, height_hint: Option<u32>) -> lightning_block_sync::AsyncBlockSourceResult<'a, lightning_block_sync::BlockHeaderData> {
+        match self {
+			AnyChainSource::Rest(client) => client.get_header(header_hash, height_hint)
+		}
+    }
+
+    fn get_block<'a>(&'a self, header_hash: &'a BlockHash) -> lightning_block_sync::AsyncBlockSourceResult<'a, BlockData> {
+        match self {
+			AnyChainSource::Rest(client) => client.get_block(header_hash)
+		}
+    }
+
+    fn get_best_block<'a>(&'a self) -> lightning_block_sync::AsyncBlockSourceResult<(BlockHash, Option<u32>)> {
+        match self {
+			AnyChainSource::Rest(client) => client.get_best_block()
+		}
+    }
+}
+
+impl UtxoSource for AnyChainSource {
+    fn get_block_hash_by_height<'a>(&'a self, block_height: u32) -> lightning_block_sync::AsyncBlockSourceResult<'a, BlockHash> {
+        match self {
+			AnyChainSource::Rest(client) => client.get_block_hash_by_height(block_height)
+		}
+    }
+
+    fn is_output_unspent<'a>(&'a self, outpoint: bitcoin::OutPoint) -> lightning_block_sync::AsyncBlockSourceResult<'a, bool> {
+        match self {
+			AnyChainSource::Rest(client) => client.is_output_unspent(outpoint)
+		}
+    }
+}
+
 pub(crate) struct ChainVerifier<L: Deref + Clone + Send + Sync + 'static> where L::Target: Logger {
-	rest_client: Arc<RestClient>,
+	chain_source: Arc<AnyChainSource>,
 	graph: Arc<NetworkGraph<L>>,
 	outbound_gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>,
 	peer_handler: Mutex<Option<GossipPeerManager<L>>>,
@@ -29,8 +67,10 @@ struct RestBinaryResponse(Vec<u8>);
 
 impl<L: Deref + Clone + Send + Sync + 'static> ChainVerifier<L> where L::Target: Logger {
 	pub(crate) fn new(graph: Arc<NetworkGraph<L>>, outbound_gossiper: Arc<P2PGossipSync<Arc<NetworkGraph<L>>, Arc<Self>, L>>, logger: L) -> Self {
+		let chain_source = Arc::new(AnyChainSource::Rest(RestClient::new(config::bitcoin_rest_endpoint()).unwrap()));
+
 		ChainVerifier {
-			rest_client: Arc::new(RestClient::new(config::bitcoin_rest_endpoint()).unwrap()),
+			chain_source,
 			outbound_gossiper,
 			graph,
 			peer_handler: Mutex::new(None),
@@ -41,12 +81,12 @@ impl<L: Deref + Clone + Send + Sync + 'static> ChainVerifier<L> where L::Target:
 		*self.peer_handler.lock().unwrap() = Some(peer_handler);
 	}
 
-	async fn retrieve_utxo(client: Arc<RestClient>, short_channel_id: u64, logger: L) -> Result<TxOut, UtxoLookupError> {
+	async fn retrieve_utxo(chain_source: Arc<AnyChainSource>, short_channel_id: u64, logger: L) -> Result<TxOut, UtxoLookupError> {
 		let block_height = (short_channel_id >> 5 * 8) as u32; // block height is most significant three bytes
 		let transaction_index = ((short_channel_id >> 2 * 8) & 0xffffff) as u32;
 		let output_index = (short_channel_id & 0xffff) as u16;
 
-		let mut block = Self::retrieve_block(client, block_height, logger.clone()).await?;
+		let mut block = Self::retrieve_block(chain_source, block_height, logger.clone()).await?;
 		if transaction_index as usize >= block.txdata.len() {
 			log_error!(logger, "Could't find transaction {} in block {}", transaction_index, block_height);
 			return Err(UtxoLookupError::UnknownTx);
@@ -59,13 +99,13 @@ impl<L: Deref + Clone + Send + Sync + 'static> ChainVerifier<L> where L::Target:
 		Ok(transaction.output.swap_remove(output_index as usize))
 	}
 
-	async fn retrieve_block(client: Arc<RestClient>, block_height: u32, logger: L) -> Result<Block, UtxoLookupError> {
-		let block_hash = client.get_block_hash_by_height(block_height).await.map_err(|error| {
+	async fn retrieve_block(chain_source: Arc<AnyChainSource>, block_height: u32, logger: L) -> Result<Block, UtxoLookupError> {
+		let block_hash = chain_source.get_block_hash_by_height(block_height).await.map_err(|error| {
 			log_error!(logger, "Could't find block hash at height {}: {:?}", block_height, error);
 			UtxoLookupError::UnknownChain
 		})?;
 
-		let block_result = client.get_block(&block_hash).await;
+		let block_result = chain_source.get_block(&block_hash).await;
 		match block_result {
 			Ok(BlockData::FullBlock(block)) => {
 				Ok(block)
@@ -84,7 +124,7 @@ impl<L: Deref + Clone + Send + Sync + 'static> UtxoLookup for ChainVerifier<L> w
 		let res = UtxoFuture::new();
 		let fut = res.clone();
 		let graph_ref = Arc::clone(&self.graph);
-		let client_ref = Arc::clone(&self.rest_client);
+		let client_ref = Arc::clone(&self.chain_source);
 		let gossip_ref = Arc::clone(&self.outbound_gossiper);
 		let pm_ref = self.peer_handler.lock().unwrap().clone();
 		let logger_ref = self.logger.clone();


### PR DESCRIPTION
- Updates the verifier to rely on both `BlockSource` and `UtxoSource` traits which the RestClient and RpcClient both implement.  Removing the unnecessary manual implementation of getblockbyhash. 
-  Introduces an enum AnyChainSource that also implements `BlockSource` and `UtxoSource` that the verifier can use.
-  Add support for bitcoind JSON-RPC api using the RpcClient.

The default behavior of using RestClient is unchanged.  This allows a user to switch to the RpcClient by setting `USE_BITCOIN_RPC_API` to "true" and providing the various `BITCOIN_RPC_*` vars (host, port, path, user, password).