### PR TITLE
bump to ldk 118

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 
 [dependencies]
 bitcoin = "0.29"
-lightning = { version = "0.0.117" }
-lightning-block-sync = { version = "0.0.117", features=["rest-client"] }
-lightning-net-tokio = { version = "0.0.117" }
+lightning = { version = "0.0.118" }
+lightning-block-sync = { version = "0.0.118", features=["rest-client"] }
+lightning-net-tokio = { version = "0.0.118" }
 tokio = { version = "1.25", features = ["full"] }
 tokio-postgres = { version = "=0.7.5" }
 futures = "0.3"
 
 [dev-dependencies]
-lightning = { version = "0.0.117", features = ["_test_utils"] }
-lightning-rapid-gossip-sync = { version = "0.0.117" }
+lightning = { version = "0.0.118", features = ["_test_utils"] }
+lightning-rapid-gossip-sync = { version = "0.0.118" }
 
 [profile.dev]
 panic = "abort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::ops::Deref;
 use std::sync::Arc;
+use bitcoin::blockdata::constants::ChainHash;
 use lightning::log_info;
 
 use lightning::routing::gossip::{NetworkGraph, NodeId};
@@ -157,8 +158,7 @@ fn serialize_empty_blob(current_timestamp: u64) -> Vec<u8> {
 	let mut blob = GOSSIP_PREFIX.to_vec();
 
 	let network = config::network();
-	let genesis_block = bitcoin::blockdata::constants::genesis_block(network);
-	let chain_hash = genesis_block.block_hash();
+	let chain_hash = ChainHash::using_genesis_block(network);
 	chain_hash.write(&mut blob).unwrap();
 
 	let blob_timestamp = Snapshotter::<Arc<RGSSLogger>>::round_down_to_nearest_multiple(current_timestamp, SYMLINK_GRANULARITY_INTERVAL as u64) as u32;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -2,8 +2,8 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bitcoin::BlockHash;
-use bitcoin::hashes::Hash;
+use bitcoin::Network;
+use bitcoin::blockdata::constants::ChainHash;
 use lightning::ln::msgs::{UnsignedChannelAnnouncement, UnsignedChannelUpdate};
 use lightning::util::ser::{BigSize, Writeable};
 use crate::config;
@@ -15,7 +15,7 @@ pub(super) struct SerializationSet {
 	pub(super) updates: Vec<UpdateSerialization>,
 	pub(super) full_update_defaults: DefaultUpdateValues,
 	pub(super) latest_seen: u32,
-	pub(super) chain_hash: BlockHash,
+	pub(super) chain_hash: ChainHash,
 }
 
 pub(super) struct DefaultUpdateValues {
@@ -109,7 +109,7 @@ pub(super) fn serialize_delta_set(delta_set: DeltaSet, last_sync_timestamp: u32)
 		announcements: vec![],
 		updates: vec![],
 		full_update_defaults: Default::default(),
-		chain_hash: BlockHash::all_zeros(),
+		chain_hash: ChainHash::using_genesis_block(Network::Bitcoin),
 		latest_seen: 0,
 	};
 
@@ -140,7 +140,7 @@ pub(super) fn serialize_delta_set(delta_set: DeltaSet, last_sync_timestamp: u32)
 		let channel_announcement_delta = channel_delta.announcement.as_ref().unwrap();
 		if !chain_hash_set {
 			chain_hash_set = true;
-			serialization_set.chain_hash = channel_announcement_delta.announcement.chain_hash.clone();
+			serialization_set.chain_hash = channel_announcement_delta.announcement.chain_hash;
 		}
 
 		let current_announcement_seen = channel_announcement_delta.seen;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,7 +4,8 @@ use std::cell::RefCell;
 use std::sync::Arc;
 use std::{fs, thread};
 use std::time::{SystemTime, UNIX_EPOCH};
-use bitcoin::{BlockHash, Network};
+use bitcoin::blockdata::constants::ChainHash;
+use bitcoin::Network;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use bitcoin::hashes::Hash;
@@ -31,8 +32,8 @@ fn blank_signature() -> Signature {
 	Signature::from_compact(&[0u8; 64]).unwrap()
 }
 
-fn genesis_hash() -> BlockHash {
-	bitcoin::blockdata::constants::genesis_block(Network::Bitcoin).block_hash()
+fn genesis_hash() -> ChainHash {
+	ChainHash::using_genesis_block(Network::Bitcoin)
 }
 
 fn current_time() -> u32 {

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::{BlockHash, TxOut};
 use bitcoin::blockdata::block::Block;
 use bitcoin::hashes::Hash;
@@ -84,7 +85,7 @@ impl<L: Deref + Clone + Send + Sync + 'static> ChainVerifier<L> where L::Target:
 }
 
 impl<L: Deref + Clone + Send + Sync + 'static> UtxoLookup for ChainVerifier<L> where L::Target: Logger {
-	fn get_utxo(&self, _genesis_hash: &BlockHash, short_channel_id: u64) -> UtxoResult {
+	fn get_utxo(&self, _genesis_hash: &ChainHash, short_channel_id: u64) -> UtxoResult {
 		let res = UtxoFuture::new();
 		let fut = res.clone();
 		let graph_ref = Arc::clone(&self.graph);


### PR DESCRIPTION
Seems like the main change here is that `UnsignedChannelAnnouncement` switched to `ChainHash` from `BlockHash`.  I changed SerializationSet to store ChainHash instead of the BlockHash.

I assume because the underlying bytes of the genesis hash should be the same(?) that this won't actually have any affect on the snapshots? I assume old ldk clients will deserialize into BlockHash without a problem?