### PR TITLE
Bump rust build image to 1.70

### DIFF
--- a/docker/Dockerfile.rgs
+++ b/docker/Dockerfile.rgs
@@ -1,4 +1,4 @@
-FROM rust:1.64
+FROM rust:1.70
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Recent version of tokio requires at least rust 1.70
> package `tokio v1.44.2` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.64.0