### PR TITLE
Fix docker setup confusions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - BITCOIN_REST_DOMAIN=bitcoin-core
       - BITCOIN_REST_PORT=8332
       - BITCOIN_REST_PATH=/rest/
-    command: 'cargo run'
+    command: 'rapid-gossip-sync-server'
 
   postgres:
     image: 'postgres:12-alpine'

--- a/docker/Dockerfile.rgs
+++ b/docker/Dockerfile.rgs
@@ -2,8 +2,7 @@ FROM rust:1.70
 
 WORKDIR /usr/src/app
 
-COPY . .
+COPY Cargo.toml Cargo.toml
+COPY src/ src/
 
 RUN cargo install --path .
-
-EXPOSE 8000


### PR DESCRIPTION
* run the actual binary (cargo run will build a develop binary)
* copy only neccesary files during docker build
* do not expose port 8000 since it is not used by the binary