### PR TITLE
Add workflow to build and push Docker images to ghcr

### DIFF
--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -1,0 +1,65 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/rapid-gossip-sync-server
+
+jobs:
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=true
+        tags: |
+          type=raw,value=latest
+          type=sha,format=long
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile.rgs
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        load: true
+        push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Print image metadata
+      run: |
+        echo "Image ID: ${{ steps.build.outputs.imageid }}"
+        echo "Digest: ${{ steps.build.outputs.digest }}"
+        echo "Metadata: ${{ steps.build.outputs.metadata }}"


### PR DESCRIPTION
This workflow builds and pushes Docker images to the GitHub Container Registry (ghcr.io).